### PR TITLE
Add Variations, improve Orders, Product Attributes, other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Many shop settings will be lost in the process, it also sets all products tax st
 - There is no refund line item on refunded orders.
 - Backorder status may not be transferred properly.
 - Featured products may not be transferred properly.
+- Product galleries may not be transferred as expected on newer versions of WP e-Commerce.
 
 ## Notes:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# WPEC to Woocommerce converter
+# WPeC to WooCommerce converter
 
-A Wordpress plugin to help migrating from WP E-Commerce to Woocommerce.
+A Wordpress plugin to help migrating from WP e-Commerce to WooCommerce.
 
 > USE AT YOUR OWN RISK!
 
 > This is a developer's plugin. We recommend that you read the code and only use it on a test version of your site.
+
+> BACK UP YOUR DATABASE! This plugin converts from WP e-Commerce to WooCommerce in place. This is a potentially destructive operation. The only way to recover if the conversion fails is to restore the database from a backup.
 
 ## Installation
 
@@ -14,16 +16,28 @@ A Wordpress plugin to help migrating from WP E-Commerce to Woocommerce.
 
 - Go to `Tools > WPeC to Woo` and check the numbers
 
+- _Optional:_ Disable WP e-Commerce, (this will speed up the migration by a lot).
+
 - Click `Convert my store` and watch the magic happen
 
 ## What it does
 
-The plugin converts **products**, **categories** and **orders** to Woocommerce. 
+The plugin converts **products**, (including variations), **categories** and **orders** to WooCommerce. 
 
-Product variations and many shop settings will be lost in the process, it also sets all products tax status to 'taxable' and the tax class to 'standard' regardless. 
+Many shop settings will be lost in the process, it also sets all products tax status to 'taxable' and the tax class to 'standard' regardless.
+
+## What it doesn't doesn't do
+
+- There is no refund line item on refunded orders.
+- Backorder status may not be transferred properly.
+- Featured products may not be transferred properly.
+
+## Notes:
+
+- Product attributes may appear in a different order than they do in the WP e-Commerce shop.
 
 ## Compatibility
 
-This has been tested on WP 3.9, using WPEC 3.8.14 and Woocommerce 2.1.8.
+This has been tested on WP 4.8.9, using WPEC 3.13.1 and Woocommerce 3.4.7.
 
 Please let us know if you have any issues or requests.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Wordpress plugin to help migrating from WP E-Commerce to Woocommerce.
 
 - Make sure Woocommerce plugin is activated.
 
-- Go to `Tools > wpec to woo` and check the numbers
+- Go to `Tools > WPeC to Woo` and check the numbers
 
 - Click `Convert my store` and watch the magic happen
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Many shop settings will be lost in the process, it also sets all products tax st
 - Backorder status may not be transferred properly.
 - Featured products may not be transferred properly.
 - Product galleries may not be transferred as expected on newer versions of WP e-Commerce.
+- Order Taxes are very USA-centric.
 
 ## Notes:
 
@@ -42,3 +43,9 @@ Many shop settings will be lost in the process, it also sets all products tax st
 This has been tested on WP 4.8.9, using WPEC 3.13.1 and Woocommerce 3.4.7.
 
 Please let us know if you have any issues or requests.
+
+## Suggestions for future improvements
+
+- Operate more on WooCommerce objects, (WC_Product, WC_Order, etc), instead of the underlying WP data.
+- Improve handling of taxes on orders, (tax rates and tax totals on orders & items in orders).
+- Improve handling of product galleries.

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -872,6 +872,18 @@ if (!class_exists("ralc_wpec_to_woo")) {
       
       // ______________________________
 
+      /**
+       * Action wpec_to_woo_update_product
+       *
+       * Called on each individual product so store owners can add 
+       * implementation-specific migrations for their products.
+       *
+       * @param int $post_id The post ID of the product that has been updated.
+       * 
+       */
+      do_action( 'wpec_to_woo_update_product', $post_id );
+
+
       // add product to log
       $this->log["products"][] = array(
         "id" => $post_id, 
@@ -1242,7 +1254,16 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
 
         $current_wc_order = false;
-        }
+
+        /**
+         * Action 'wpec_to_woo_update_order' 
+         *
+         * @param int $post_id The ID of the new WooCommerce Order CPT that was created
+         * @param array $order Row from WPeC's Purchase Log table that is the source of the migrated order.
+         * @param \WC_Order $current_wc_order The WooCommerce order object that corresponds to $post_id.
+         */
+        do_action( 'wpec_to_woo_update_order', $post_id, $order, $current_wc_order );
+      }
 
     }// END: update_orders()
 
@@ -1354,6 +1375,16 @@ if (!class_exists("ralc_wpec_to_woo")) {
         if( $wpec_order['processed'] > 2 ) {
           update_post_meta( $post_id, '_wc_authorize_net_aim_trans_date', date_i18n( 'Y-m-d H:i:s', $wpec_order['date'], true ) );
         }
+
+        /**
+         * Action 'wpec_to_woo_update_order_meta'
+         *
+         * @param int $post_id The post ID of the WooCommerce Order CPT created for this order.
+         * @param array $order Row from WPeC's Purchase Log table that is the source of the migrated order.
+         * @param \WC_Order $current_wc_order The WooCommerce order object that corresponds to $post_id.
+         * @param array $order_meta WPeC's Order Metadata, corresponds to a row from the wpsc_purchase_meta table.
+         */
+        do_action( 'wpec_to_woo_update_order_meta', $post_id, $wpec_order, $current_wc_order, $order_meta );
         
     }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -33,28 +33,35 @@ if (!class_exists("ralc_wpec_to_woo")) {
        * Hooks for sending emails during store events
        * From: https://docs.woocommerce.com/document/unhookremove-woocommerce-emails/
        **/
-      remove_action( 'woocommerce_low_stock_notification', array( $email_class, 'low_stock' ) );
-      remove_action( 'woocommerce_no_stock_notification', array( $email_class, 'no_stock' ) );
-      remove_action( 'woocommerce_product_on_backorder_notification', array( $email_class, 'backorder' ) );
-      
-      // New order emails
-      remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_pending_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_failed_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_failed_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
-      
-      // Processing order emails
-      remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
-      remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
-      
-      // Completed order emails
-      remove_action( 'woocommerce_order_status_completed_notification', array( $email_class->emails['WC_Email_Customer_Completed_Order'], 'trigger' ) );
-        
-      // Note emails
-      remove_action( 'woocommerce_new_customer_note_notification', array( $email_class->emails['WC_Email_Customer_Note'], 'trigger' ) );
 
+      if( class_exists('WC_Emails') ) {
+
+        $email_class = \WC_Emails::instance();
+
+        remove_action( 'woocommerce_low_stock_notification', array( $email_class, 'low_stock' ) );
+        remove_action( 'woocommerce_no_stock_notification', array( $email_class, 'no_stock' ) );
+        remove_action( 'woocommerce_product_on_backorder_notification', array( $email_class, 'backorder' ) );
+        
+        // New order emails
+        remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_pending_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_failed_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_failed_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+        
+        // Processing order emails
+        remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+        remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+        
+        // Completed order emails
+        remove_action( 'woocommerce_order_status_completed_notification', array( $email_class->emails['WC_Email_Customer_Completed_Order'], 'trigger' ) );
+          
+        // Note emails
+        remove_action( 'woocommerce_new_customer_note_notification', array( $email_class->emails['WC_Email_Customer_Note'], 'trigger' ) );
+
+      }
+      
 
       // Turn off E-mails not included in the above, from wc-update-functions.php
       remove_all_actions( 'woocommerce_order_status_refunded_notification' );

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -407,6 +407,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     	$this->update_products();
 
+      $this->update_menu_items();
+
     	$this->update_categories(); 
 
     	$this->update_coupons();
@@ -417,6 +419,15 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // $this->delete_redundant_wpec_datbase_entries();         
     }// END: conversion
 
+
+    public function update_menu_items() {
+      global $wpdb;
+
+      $wpdb->query( "UPDATE {$wpdb->postmeta} SET meta_value='product' WHERE meta_key='_menu_item_object' AND meta_value='wpsc-product'" );
+
+    }
+
+    
     public function show_log(){
 ?>
       <div id="log" class="metabox-holder">

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -437,8 +437,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
                   </tr>
                   <?php foreach( $this->log["products"] as $product ): ?>
                   <tr>
-                    <td><?php echo $product["id"] ?></td>
-                    <td><a href="post.php<?php echo $product["link"] ?>"><?php echo $product["title"] ?></a></td>
+                    <td><?php esc_html_e( $product["id"] ); ?></td>
+                    <td><a href="post.php<?php esc_attr_e( $product["link"] ); ?>"><?php esc_html_e( $product["title"] ); ?></a></td>
                   </tr>
                   <?php endforeach; ?>
                   <?php endif; ?>
@@ -449,7 +449,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
             <?php if( $this->log["categories"] ): ?>
             <div class="segment">
               <h4>Categories</h4>
-              <h5><?php echo $this->log["categories"]["updated"] ?> categories updated</h5>
+              <h5><?php esc_html_e( $this->log["categories"]["updated"] ); ?> categories updated</h5>
               <table>
                 <tbody>
                   <tr>
@@ -472,7 +472,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
                     <th>Notices</th>
                   </tr>
                   <tr>
-                    <td><a href="post.php/<?php echo $coupon["link"] ?>"><?php echo $coupon["title"] ?></a></td>
+                    <td><a href="post.php/<?php esc_attr_e( $coupon["link"] ); ?>"><?php esc_html_e( $coupon["title"] ); ?></a></td>
                     <td><?php echo (isset($coupon['active']) ? $coupon['active'] : '' ); ?></td>
                     <?php if(isset($coupon["conditions"]) && $coupon["conditions"] && isset($coupon["free-shipping"]) && $coupon["free-shipping"] ): ?>
                     <td>This coupon was set to be in-active because it currently makes use of the conditions feature and the free shipping of wpec which is not supported by woocommerce</td>
@@ -499,7 +499,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
                   </tr>
                   <?php foreach( $this->log["orders"] as $order ): ?>
                   <tr>
-                    <td><?php echo $order["name"] ?></td>
+                    <td><?php esc_html_e( $order["name"] ); ?></td>
                   </tr>
                   <?php endforeach; ?>
                 <?php endif; ?>
@@ -853,7 +853,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // add product to log
       $this->log["products"][] = array(
         "id" => $post_id, 
-        "title" => get_the_title(),
+        "title" => $post->post_title,
         "link" => "?post=". $post_id ."&action=edit"
         );
       endwhile;

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -893,15 +893,13 @@ if (!class_exists("ralc_wpec_to_woo")) {
           'post_parent' => '0',
           'post_status' => self::convert_order_status($order['processed']),
           'post_title' => $post_title,
-          'post_type' => 'shop_order' 
+          'post_type' => 'shop_order',
+          'post_date' => date_i18n( 'Y-m-d H:i:s', $order['date'] ),
+          'post_date_gmt' => date_i18n( 'Y-m-d H:i:s', $order['date'], true ),
           );
         // insert post
         $post_id = wp_insert_post( $post, true );
 
-        // wpec tables
-        $wpsc_purchase_logs_table = $wpdb->prefix . 'wpsc_purchase_logs';
-        $wpsc_submited_form_data_table = $wpdb->prefix . 'wpsc_submited_form_data';
-        $wpsc_checkout_forms_table = $wpdb->prefix . 'wpsc_checkout_forms';
 
         $this->update_order_contact_info( $post_id, $order);
 
@@ -1015,12 +1013,6 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_order_currency', "EUR" );
         update_post_meta( $post_id, '_prices_include_tax', "no" );
 
-        // order date
-        wp_update_post(array(
-          'ID' => $post_id,
-          'post_date' => date_i18n( 'Y-m-d H:i:s', $extrainfo->date ),
-          'post_date_gmt' => date_i18n( 'Y-m-d H:i:s', $extrainfo->date, true ),
-          ));
 
 
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -17,6 +17,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
     // just get the id of the first administrator in the database
     var $post_author;
 
+    // Set defaults for Shipping & Billing country
+    var $default_shipping_country = 'US';
+    var $default_billing_country = 'US';
+
     function ralc_wpec_to_woo() { } // constructor
     
     function plugin_menu() {
@@ -860,7 +864,12 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_billing_address_2', "" );
         update_post_meta( $post_id, '_billing_city', $userinfo['billingcity'] );
         update_post_meta( $post_id, '_billing_postcode', $userinfo['billingpostcode'] );
-        update_post_meta( $post_id, '_billing_country', $userinfo['billingcountry'] );
+        if( isset( $userinfo['billingcountry'])) {
+          update_post_meta( $post_id, '_billing_country', $userinfo['billingcountry'] );
+        } else {
+          update_post_meta( $post_id, '_billing_country', $this->default_billing_country );
+        }
+        
         update_post_meta( $post_id, '_billing_email', $userinfo['billingemail'] );
         update_post_meta( $post_id, '_billing_phone', $userinfo['billingphone'] );                
 
@@ -872,7 +881,11 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_shipping_address_2', "" );
         update_post_meta( $post_id, '_shipping_city', $userinfo['shippingcity'] );
         update_post_meta( $post_id, '_shipping_postcode', $userinfo['shippingpostcode'] );
-        update_post_meta( $post_id, '_shipping_country', $userinfo['shippingcountry'] );
+        if(isset($userinfo['shippingcountry'])) {
+          update_post_meta( $post_id, '_shipping_country', $userinfo['shippingcountry'] );
+        } else {
+          update_post_meta( $post_id, '_shipping_country', $this->default_shipping_country );
+        }
         update_post_meta( $post_id, '_shipping_state', "" );
 
         /*

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -24,6 +24,43 @@ if (!class_exists("ralc_wpec_to_woo")) {
     public function __construct() { 
       //
     }
+
+    protected function disable_emails() {
+      /**
+       * Hooks for sending emails during store events
+       * From: https://docs.woocommerce.com/document/unhookremove-woocommerce-emails/
+       **/
+      remove_action( 'woocommerce_low_stock_notification', array( $email_class, 'low_stock' ) );
+      remove_action( 'woocommerce_no_stock_notification', array( $email_class, 'no_stock' ) );
+      remove_action( 'woocommerce_product_on_backorder_notification', array( $email_class, 'backorder' ) );
+      
+      // New order emails
+      remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_pending_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_failed_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_failed_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+      
+      // Processing order emails
+      remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+      remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+      
+      // Completed order emails
+      remove_action( 'woocommerce_order_status_completed_notification', array( $email_class->emails['WC_Email_Customer_Completed_Order'], 'trigger' ) );
+        
+      // Note emails
+      remove_action( 'woocommerce_new_customer_note_notification', array( $email_class->emails['WC_Email_Customer_Note'], 'trigger' ) );
+
+
+      // Turn off E-mails not included in the above, from wc-update-functions.php
+      remove_all_actions( 'woocommerce_order_status_refunded_notification' );
+      remove_all_actions( 'woocommerce_order_partially_refunded_notification' );
+      remove_action( 'woocommerce_order_status_refunded', array( 'WC_Emails', 'send_transactional_email' ) );
+      remove_action( 'woocommerce_order_partially_refunded', array( 'WC_Emails', 'send_transactional_email' ) );
+
+
+    }
     
     public function plugin_menu() {
       $page = add_submenu_page( 'tools.php', 'wpec to woo', 'wpec to woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
@@ -293,6 +330,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     public function conversion(){ 
     	global $wpdb;
+
+      // Don't send E-mail by accident while converting. 
+      // We don't want customers getting a bunch of E-mails!
+      $this->disable_emails();
       // just get the id of the first administrator in the database
     	$this->post_author = $wpdb->get_var( "SELECT ID FROM $wpdb->users;" );
     	$this->update_shop_settings();          

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -523,7 +523,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       $regular_price = get_post_meta($post_id, '_wpsc_price', true);
       update_post_meta($post_id, '_regular_price', $regular_price);               
       $sale_price = get_post_meta($post_id, '_wpsc_special_price', true);
-      if( $sale_price != '' && $sale_price != $regular_price ){
+      if( !empty($sale_price) && $sale_price != $regular_price ){
         update_post_meta($post_id, '_price', $sale_price);
         update_post_meta($post_id, '_sale_price', $sale_price);
       }else{

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -957,19 +957,40 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
 
         $this->update_order_items( $post_id, $order );
+
+        $this->update_order_meata( $post_id, $order );
         
+        // add to log
+        $this->log['orders'][] = array(
+          'name' => $post_title
+          );
+
+        }
+
+    }// END: update_orders()
+
+
+    // @TODO: Incomplete.
+    protected function update_order_meta( $post_id, $wpec_order ) {
+
+          // wpec tables
+        $wpsc_purchase_logs_table = $wpdb->prefix . 'wpsc_purchase_logs';
+        $wpsc_submited_form_data_table = $wpdb->prefix . 'wpsc_submited_form_data';
+        $wpsc_checkout_forms_table = $wpdb->prefix . 'wpsc_checkout_forms';
+      
 
         /*
           ORDER DATA
         */
-        $extrainfo = $wpdb->get_results("
-          SELECT DISTINCT `" . $wpsc_purchase_logs_table . "` . * 
-          FROM `" . $wpsc_submited_form_data_table . "`
-          LEFT JOIN `" . $wpsc_purchase_logs_table . "`
-          ON `" . $wpsc_submited_form_data_table . "`.`log_id` = `" . $wpsc_purchase_logs_table . "`.`id`
-          WHERE `" . $wpsc_purchase_logs_table . "`.`id`=" . $order['id'] . "
-          ");
-        $extrainfo = $extrainfo[0];              
+        $extrainfo = $wpdb->get_row(  $wpdb->prepare("
+          SELECT DISTINCT `{$wpdb->prefix}wpsc_purchase_logs` . * 
+          FROM `{$wpdb->prefix}wpsc_submitted_form_data`
+          LEFT JOIN `{$wpdb->prefix}wpsc_purchase_logs`
+          ON `{$wpdb->prefix}wpsc_submitted_form_data`.`log_id` = `{$wpdb->prefix}wpsc_purchase_logs`.`id`
+          WHERE `{$wpdb->prefix}wpsc_purchase_logs`.`id`=%d
+          "), $wpec_order['id'] );
+
+
         update_post_meta( $post_id, '_payment_method', $extrainfo->gateway );
 
         // @TODO: Fix these. They should not all be the same. 
@@ -991,19 +1012,6 @@ if (!class_exists("ralc_wpec_to_woo")) {
           ));
 
 
-        // add to log
-        $this->log['orders'][] = array(
-          'name' => $post_title
-          );
-
-        }
-
-    }// END: update_orders()
-
-    protected function update_order_meta( $post_id, $wpec_order ) {
-
-
-      //update_post_meta( $post_id, )
 
     }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -153,7 +153,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         <form method="post" action="tools.php?page=wpec-to-woo">
           <input type="hidden" name="order" value="go_go_go" />
           <p>
-            <input type="checkbox" name="delete_orders" value="yes" checked="checked" />
+            <input type="checkbox" name="delete_orders" value="yes" />
             Delete all orders
           </p>
           <input class="button-primary" type="submit" value="Convert My Store" />

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -504,9 +504,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // wp-e stores all the featured products in one place
       $featured_products = get_option('sticky_products', false);
 
-      while ( $products->have_posts() ) : $products->the_post();
+      while ( $products->have_posts() ) : 
         set_time_limit(120);
-      $post_id = get_the_id();
+        $post = $products->next_post();
+      $post_id = $post->ID;
       $count ++;
 
       // ______ POST TYPE ______

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -413,6 +413,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       $featured_products = get_option('sticky_products', false);
 
       while ( $products->have_posts() ) : $products->the_post();
+        set_time_limit(120);
       $post_id = get_the_id();
       $count ++;
 
@@ -689,6 +690,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // loop through coupons            
       foreach ( (array)$coupon_data as $coupon ):  
 
+        set_time_limit(120);
+
       $post_title = sanitize_title( $coupon['coupon_code'] );
       // check to see if coupon has already been added
       $coupon_exists = $wpdb->get_var($wpdb->prepare("
@@ -805,6 +808,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
     public function delete_orders(){
       $mycustomposts = get_posts( array( 'post_type' => 'shop_order', 'posts_per_page' => 9999) );
       foreach( $mycustomposts as $mypost ){
+        set_time_limit(120);
         wp_delete_post( $mypost->ID, true);
       }
     }
@@ -817,6 +821,9 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
       $order_data = $wpdb->get_results( "SELECT * FROM `" . $wpec_order_table . "`", ARRAY_A );
       foreach ( (array)$order_data as $order ){
+        
+        set_time_limit(120);
+
         $post_title = "WPEC Order - " . $order['id'] . " - " . date( 'Y-m-d H:i:s', $order['date'] );
 
         // check to see if order has already been added

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -53,10 +53,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
         <h2>Wp-e-commerce to woocommerce converter</h2>
         <p>Use at your own risk!, still working on it, only use it on a test version of your site. Read the help for more information.</p>         
         <?php
-        if( $_POST['delete_orders'] == 'yes' ){
+        if( isset($_POST['delete_orders']) && $_POST['delete_orders'] == 'yes' ){
           $this->delete_orders();
         }
-        if( $_POST['order'] == 'go_go_go' ){
+        if( isset($_POST['order']) && $_POST['order'] == 'go_go_go' ){
           $this->conversion();
         }
         $this->at_a_glance();

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -913,7 +913,12 @@ if (!class_exists("ralc_wpec_to_woo")) {
           }
         }
 
-        $attributes = array_merge( get_post_meta( $post_id, '_product_attributes', true ), $attributes );
+        $existing_attributes = get_post_meta( $post_id, '_product_attributes', true );
+        if( '' == $existing_attributes ) {
+          $existing_attributes = [];
+        }
+
+        $attributes = array_merge( $existing_attributes, $attributes );
 
         update_post_meta( $post_id, '_product_attributes', $attributes );
     }

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -971,6 +971,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
           ");
         $extrainfo = $extrainfo[0];              
         update_post_meta( $post_id, '_payment_method', $extrainfo->gateway );
+
+        // @TODO: Fix these. They should not all be the same. 
         update_post_meta( $post_id, '_order_shipping', $extrainfo->base_shipping );
         update_post_meta( $post_id, '_order_discount', $extrainfo->base_shipping );
         update_post_meta( $post_id, '_cart_discount', $extrainfo->base_shipping );

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -24,6 +24,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     var $taxes_included = false;
 
+    var $admin_page_identifier = '';
+
     public function __construct() { 
       //
     }
@@ -99,14 +101,29 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     
     public function plugin_menu() {
-      $page = add_submenu_page( 'tools.php', 'WPeC to WooCommerce', 'WPeC to Woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
-      add_action( 'admin_print_styles-' . $page, array( $this, 'admin_styles' ) );
+      $this->admin_page_identifier = add_submenu_page( 'tools.php', 'WPeC to WooCommerce', 'WPeC to Woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
 
-      $help = '<p>The idea is you run this on a wordpress shop already setup with wp-e-commerce. Then this code will convert as much as it can into a woocommerce a shop. Make sure you have the Woocommerce plugin activated.</p>';
-      $help .= '<p>Currently only converting products and categories, plan to try and convert the orders too. Because the sites i\'m writing this for don\'t have any variations on products i have not taken the time to work out a system for them. It also sets all products tax status to \'taxable\' and the tax class to \'standard\' regardless.</p>';          
-      $help .= '<p><b>One last caveat:</b> i\'m working with version:3.8.6 of wp-e-commerce, things may well have changed with the lastest version but the shops i need to convert are on this version and i\'m not interested in trying to upgrade them because of the many problems i have been having each time i upgrade the wp-e-commerce plugin. I\'ll test the plugin with the latest verion at a later date.</p>';
-      get_current_screen( $page, $help );
+      add_action( 'load-' . $this->admin_page_identifier, [ $this, 'show_contextual_help'] );
+
+      add_action( 'admin_print_styles-' . $this->admin_page_identifier, array( $this, 'admin_styles' ) );
+
+    
     }// END: plugin_menu
+
+    public function show_contextual_help() {
+      $help = '<p>The idea is you run this on a WordPress shop already setup with WP e-Commerce. Then this code will convert as much as it can into WooCommerce data. Make sure you have the WooCommerce plugin activated.</p>';
+      $help .= '<p>Currently converts products and categories, variations and orders. All products tax status will be set to to \'taxable\' and the tax class to \'standard\'.</p>';          
+      $help .= '<p><b>One last caveat:</b> This has been used with versions 3.8.6 and 3.13.1 of WP e-Commerce. It may work with other versions, and it may not. <b>TEST</b> on a development copy. <b>MAKE A BACKUP</b> before using this plugin; by nature it is destructive and the only way to recover from a failed migration will be your database backup.</p>';
+
+
+      $screen = get_current_screen();
+      $screen->add_help_tab( array(
+        'id'       => 'wpec-to-woo',
+        'title'    => __( 'WP e-Commerce to WooCommerce' ),
+        'content'  => $help
+      ));
+
+    }
     
     public function admin_styles() {
       wp_enqueue_style( 'wpec_to_woo_styles' );

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -479,7 +479,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // ______ OTHER PRODUCT DATA ______
       // sku code
       $sku = get_post_meta($post_id, '_wpsc_sku', true);
-      if( $sku == null ){
+      if( $sku == null && !empty($_wpsc_product_metadata['_wpsc_sku'])){
         // try the old name
         $sku = $_wpsc_product_metadata['_wpsc_sku'];
       }

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -492,29 +492,35 @@ if (!class_exists("ralc_wpec_to_woo")) {
       $tax_class = '';
       update_post_meta($post_id, '_tax_class', $sku);
 
-      // weight
-      $weight = $_wpsc_product_metadata['weight'];
+      if( isset( $_wpsc_product_metadata['weight'])) {
+        // weight
+        $weight = $_wpsc_product_metadata['weight'];
 
-      update_post_meta($post_id, '_weight', $weight);
+        update_post_meta($post_id, '_weight', $weight);
+      }
+
+
       /*
        * WPEC use to use ['_wpsc_dimensions'] but then changed to use ['dimensions']
        * some products may still have the old variable name
        */
-      $dimensions = $_wpsc_product_metadata['dimensions'];
-      if( $dimensions == null ){
-        // try the old name
-      	$dimensions = $_wpsc_product_metadata['_wpsc_dimensions'];
+      $dimensions = null;
+      if( isset( $_wpsc_product_metadata['dimensions'] ) ) {
+        $dimensions = $_wpsc_product_metadata['dimensions'];
+      } else if( isset( $_wpsc_product_metadata['_wpsc_dimensions'] )) {
+        $dimensions = $_wpsc_product_metadata['_wpsc_dimensions'];
       }
-      // height
-      $height = $dimensions['height'];
-      update_post_meta($post_id, '_height', $height);
-      //length
-      $length = $dimensions['length'];
-      update_post_meta($post_id, '_length', $length);
-      //width
-      $width = $dimensions['width'];
-      update_post_meta($post_id, '_width', $width);
-      
+      if( !empty($dimensions) ) {
+        // height
+        $height = $dimensions['height'];
+        update_post_meta($post_id, '_height', $height);
+        //length
+        $length = $dimensions['length'];
+        update_post_meta($post_id, '_length', $length);
+        //width
+        $width = $dimensions['width'];
+        update_post_meta($post_id, '_width', $width);
+      }
       /* woocommerce option update, weight unit and dimentions unit */
       if( $count == 1 ){
         /*
@@ -523,18 +529,22 @@ if (!class_exists("ralc_wpec_to_woo")) {
          * and just use those values for the global values used store wide in woocommerce
          */
         $weight_unit = $_wpsc_product_metadata['weight_unit'];
-        $dimentions_unit = $dimensions['height_unit'];
+
         if( $weight_unit == "pound" || $weight_unit == "ounce" || $weight_unit == "gram" ){
         	$weight_unit = "lbs";
         }else{
         	$weight_unit = "kg";
         }
-        if( $dimentions_unit == "cm" || $dimentions_unit == "meter" ){
-        	$dimentions_unit = "cm";
-        }else{
-        	$dimentions_unit = "in";
-        }
         update_option( 'woocommerce_weight_unit', $weight_unit );
+
+        $dimensions_unit = "in";
+        if( !empty( $dimensions ) ) {
+          $dimentions_unit = $dimensions['height_unit'];
+
+          if( $dimentions_unit == "cm" || $dimentions_unit == "meter" ){
+            $dimentions_unit = "cm";
+          }
+        }
         update_option( 'woocommerce_dimension_unit', $dimentions_unit );
       }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -287,7 +287,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         <?php
     } // at_a_glance()
 
-    function conversion(){ 
+    public function conversion(){ 
     	global $wpdb;
       // just get the id of the first administrator in the database
     	$this->post_author = $wpdb->get_var( "SELECT ID FROM $wpdb->users;" );
@@ -300,7 +300,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // $this->delete_redundant_wpec_datbase_entries();         
     }// END: conversion
 
-    function show_log(){
+    public function show_log(){
 ?>
       <div id="log" class="metabox-holder">
         <div class="postbox">

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -204,7 +204,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
                       <td class="b first"><a href="#">
                         <?php 
                         $wpec_products = wp_count_posts( 'wpsc-product' );
-                        echo number_format_i18n( $wpec_products->publish ); 
+                        echo number_format_i18n( isset( $wpec_products->publish ) ? $wpec_products->publish : 0 ); 
                         ?>
                       </a></td>
                       <td class="t"><a href="#">Products<a/></td>

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1010,7 +1010,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         // wpec_auth_net
         // wpsc_merchant_paypal_express
         // wpsc_merchant_vmerchant
-        switch( $order->gateway ) {
+        switch( $order['gateway'] ) {
           case 'wpec_auth_net':
             $this->update_wpec_auth_net();
           break;
@@ -1099,11 +1099,11 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
       
         // Update values from $wpec_order;
-        update_post_meta( $post_id, '_payment_method', $wpec_order->gateway );
-        update_post_meta( $post_id, '_transaction_id', $wpec_order->transactid );
-        update_post_meta( $post_id, '_order_discount', $wpec_order->discount_value );
-        update_post_meta( $post_id, '_order_tax', $wpec_order->wpec_taxes_total );
-        update_post_meta( $post_id, '_order_total', $wpec_order->totalprice );
+        update_post_meta( $post_id, '_payment_method', $wpec_order['gateway'] );
+        update_post_meta( $post_id, '_transaction_id', $wpec_order['transactid'] );
+        update_post_meta( $post_id, '_order_discount', $wpec_order['discount_value'] );
+        update_post_meta( $post_id, '_order_tax', $wpec_order['wpec_taxes_total'] );
+        update_post_meta( $post_id, '_order_total', $wpec_order['totalprice'] );
         
 
         // Update hardcoded or generated values.
@@ -1116,16 +1116,15 @@ if (!class_exists("ralc_wpec_to_woo")) {
         
 
         // Update values stored in purchase meta
-        $order_meta = get_metadata( 'wpsc_purchase', $wpec_order->id );
+        $order_meta = get_metadata( 'wpsc_purchase', $wpec_order['id'] );
         if( !empty( $order_meta['gateway_name'] ) ) {
           update_post_meta( $post_id, '_payment_method_title', $order_meta['gateway_name'][0] );
         }
         
         if( !empty( $order_meta['total_shipping'] ) ) {
           update_post_meta( $post_id, '_order_shipping', $order_meta['total_shipping'][0] ); 
-          // @TODO: fallback to $wpec_order->base_shipping if not available in meta.
         } else {
-          update_post_meta( $post_id, '_order_shipping', $wpec_order->base_shipping );
+          update_post_meta( $post_id, '_order_shipping', $wpec_order['base_shipping'] );
         }
         
         // Set the "Prices Include Tax" item based on the WPeC store setting.
@@ -1138,15 +1137,15 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
       global $wpdb;
 
-      $transaction_id = $wpec_order->transactid;
-      $auth_code = $wpec_order->authcode;
+      $transaction_id = $wpec_order['transactid'];
+      $auth_code = $wpec_order['authcode'];
 
       
 
       $authnet_meta_raw = $wpdb->get_var( 
         $wpdb->prepare(
           "SELECT meta_value FROM {$wpdb->wpsc_meta} WHERE object_id=%d AND meta_key='_wpsc_auth_net_status'", 
-          $wpec_order->id
+          $wpec_order['id']
         )
       );
 
@@ -1188,7 +1187,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
       
       
-      update_post_meta( $post_id, '_wc_authorize_net_aim_trans_date', date_i18n( 'Y-m-d H:i:s', $wpec_order->date, true ) );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_trans_date', date_i18n( 'Y-m-d H:i:s', $wpec_order['date'], true ) );
       update_post_meta( $post_id, '_wc_authorize_net_aim_environment', 'production' );
 
     }

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -656,13 +656,13 @@ if (!class_exists("ralc_wpec_to_woo")) {
         $dimensions_unit = "in";
         if( !empty( $dimensions ) && isset($dimensions['height_unit']) ) {
 
-          $dimentions_unit = $dimensions['height_unit'];
+          $dimensions_unit = $dimensions['height_unit'];
 
-          if( $dimentions_unit == "cm" || $dimentions_unit == "meter" ){
-            $dimentions_unit = "cm";
+          if( $dimensions_unit == "cm" || $dimensions_unit == "meter" ){
+            $dimensions_unit = "cm";
           }
         }
-        update_option( 'woocommerce_dimension_unit', $dimentions_unit );
+        update_option( 'woocommerce_dimension_unit', $dimensions_unit );
       }
 
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -541,7 +541,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_option( 'woocommerce_weight_unit', $weight_unit );
 
         $dimensions_unit = "in";
-        if( !empty( $dimensions ) ) {
+        if( !empty( $dimensions ) && isset($dimensions['height_unit']) ) {
+
           $dimentions_unit = $dimensions['height_unit'];
 
           if( $dimentions_unit == "cm" || $dimentions_unit == "meter" ){

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -137,7 +137,6 @@ if (!class_exists("ralc_wpec_to_woo")) {
       if (!current_user_can('manage_options'))  {
         wp_die( __('You do not have sufficient permissions to access this page.') );
       }
-
       ?>
       <div class="wrap">
         <h2>Wp-e-commerce to woocommerce converter</h2>
@@ -412,7 +411,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     	$this->update_coupons();
     	
-      $this->update_orders();
+//      $this->update_orders();
 
       // tags don't need to be updated as both wpec and woo use the same name for the taxonomy 'product_tag'
       // $this->delete_redundant_wpec_datbase_entries();         
@@ -741,6 +740,8 @@ if (!class_exists("ralc_wpec_to_woo")) {
       if( count( $attributes ) > 0 ) {
         update_post_meta( $post->ID, '_product_attributes', $attributes );  
       }
+
+      $this->update_product_attributes( $post->ID );
       
 
       // _____________________________________
@@ -858,6 +859,30 @@ if (!class_exists("ralc_wpec_to_woo")) {
       endwhile;
 
     }// END: update_products
+
+
+    protected function update_product_attributes( $post_id ) {
+
+        $postmeta = get_post_meta( $post_id );
+
+        $attributes = [];
+        foreach( $postmeta as $metakey => $metaval ) {
+          if(mb_strpos( $metakey, '_' ) !== 0 && mb_strpos( $metakey, 'five-star-rating-widget' ) === false ) {
+            $attr = [
+              'name' => $metakey,
+              'value' => $metaval[0],
+              'is_variation' => 0,
+              'is_taxonomy' => 0,
+              'is_visible' => 1,
+            ];
+            $attributes[ sanitize_title($attr['name']) ] = $attr;
+          }
+        }
+
+        $attributes = array_merge( get_post_meta( $post_id, '_product_attributes', true ), $attributes );
+
+        update_post_meta( $post_id, '_product_attributes', $attributes );
+    }
     
 
     /**

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -721,7 +721,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       if ( ! isset( $has_variations[ $post_id ] ) ) {
         $args = array(
           'post_parent' => $post_id,
-          'post_type'   => 'wpsc-product',
+          'post_type'   => 'product_variation',
           'post_status' => array( 'inherit', 'publish' ),
         );
         $children = get_children( $args );

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -99,7 +99,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     
     public function plugin_menu() {
-      $page = add_submenu_page( 'tools.php', 'wpec to woo', 'wpec to woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
+      $page = add_submenu_page( 'tools.php', 'WPeC to WooCommerce', 'WPeC to Woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
       add_action( 'admin_print_styles-' . $page, array( $this, 'admin_styles' ) );
 
       $help = '<p>The idea is you run this on a wordpress shop already setup with wp-e-commerce. Then this code will convert as much as it can into a woocommerce a shop. Make sure you have the Woocommerce plugin activated.</p>';

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -21,9 +21,11 @@ if (!class_exists("ralc_wpec_to_woo")) {
     var $default_shipping_country = 'US';
     var $default_billing_country = 'US';
 
-    function ralc_wpec_to_woo() { } // constructor
+    public function __construct() { 
+      //
+    }
     
-    function plugin_menu() {
+    public function plugin_menu() {
       $page = add_submenu_page( 'tools.php', 'wpec to woo', 'wpec to woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
       add_action( 'admin_print_styles-' . $page, array( $this, 'admin_styles' ) );
 
@@ -33,15 +35,15 @@ if (!class_exists("ralc_wpec_to_woo")) {
       get_current_screen( $page, $help );
     }// END: plugin_menu
     
-    function admin_styles() {
+    public function admin_styles() {
       wp_enqueue_style( 'wpec_to_woo_styles' );
     }
     
-    function admin_init() {
+    public function admin_init() {
       wp_register_style( 'wpec_to_woo_styles', plugins_url('styles.css', __FILE__) );
     }
 
-    function plugin_options() {
+    public function plugin_options() {
       if (!current_user_can('manage_options'))  {
         wp_die( __('You do not have sufficient permissions to access this page.') );
       }
@@ -76,7 +78,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       <?php
       } //END: plugin_options
         
-    function at_a_glance(){
+    public function at_a_glance(){
       global $wpdb; global $woocommerce;
       ?>
       <div id="glance" class="metabox-holder">
@@ -399,7 +401,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
      * convert post type to woocommerce post type
      * update price field meta
      */
-    function update_products(){
+    public function update_products(){
       $args = array( 
         'post_type' => $this->old_post_type, 
         'posts_per_page' => -1,
@@ -591,7 +593,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
     /*
      * update category
      */
-    function update_categories(){
+    public function update_categories(){
       global $wpdb;
 
       //$wpdb->show_errors(); 
@@ -619,7 +621,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       $wpdb->flush();
     }// END: update_categories
         
-    function update_shop_settings(){
+    public function update_shop_settings(){
       global $wpdb;
       /*
        * were only going to update some straight forward options
@@ -673,7 +675,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     }  
 
-    function update_coupons(){
+    public function update_coupons(){
       global $wpdb;
        // get all coupons
       $wpec_coupon_table = $wpdb->prefix . 'wpsc_coupon_codes';
@@ -800,14 +802,14 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     }// END: update_coupons()
 
-    function delete_orders(){
+    public function delete_orders(){
       $mycustomposts = get_posts( array( 'post_type' => 'shop_order', 'posts_per_page' => 9999) );
       foreach( $mycustomposts as $mypost ){
         wp_delete_post( $mypost->ID, true);
       }
     }
     
-    function update_orders(){
+    public function update_orders(){
       global $wpdb;
       // loop through orders
       $wpec_order_table = $wpdb->prefix . 'wpsc_purchase_logs';
@@ -988,7 +990,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     }// END: update_orders()
         
-    function delete_redundant_wpec_datbase_entries(){
+    public function delete_redundant_wpec_datbase_entries(){
       global $wpdb;
       /* delete all wpec database entries */
       delete_post_meta($post_id, '_wpsc_price');

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -381,13 +381,22 @@ if (!class_exists("ralc_wpec_to_woo")) {
       } else {
         $this->taxes_included = true;
       }
+
       // just get the id of the first administrator in the database
     	$this->post_author = $wpdb->get_var( "SELECT ID FROM $wpdb->users;" );
-    	$this->update_shop_settings();          
+    	
+      $this->update_shop_settings();
+
+      $this->update_variations();
+
     	$this->update_products();
+
     	$this->update_categories(); 
+
     	$this->update_coupons();
-    	$this->update_orders();
+    	
+      $this->update_orders();
+
       // tags don't need to be updated as both wpec and woo use the same name for the taxonomy 'product_tag'
       // $this->delete_redundant_wpec_datbase_entries();         
     }// END: conversion

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1287,8 +1287,21 @@ if (!class_exists("ralc_wpec_to_woo")) {
         ", $wpec_order['id'] ), ARRAY_A );
 
 
-      foreach($userinfo as $info){
-        $userinfo[$info['unique_name']] = $info['value'];
+      foreach( $userinfo as $info ) {
+        // Handle the possibility of multiple rows with the same unique_name.
+        if( isset( $userinfo[ $info['unique_name'] ] ) ) {
+          if( is_array( $userinfo[ $info['unique_name'] ] ) ) {
+            $userinfo[ $info['unique_name'] ][] = $info['value'];
+          } else {
+            $userinfo[ $info['unique_name'] ] = [
+              $userinfo[ $info['unique_name'] ],
+              $info['value']
+            ];
+          }
+        } else {
+          $userinfo[ $info['unique_name'] ] = $info['value'];
+        }
+        
       }
 
       // ID

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -20,6 +20,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
     // Set defaults for Shipping & Billing country
     var $default_shipping_country = 'US';
     var $default_billing_country = 'US';
+    var $default_order_currency = 'USD';
 
     public function __construct() { 
       //
@@ -920,8 +921,6 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
       global $wpdb;
 
-      
-
       /*
         CUSTOMER DATA
       */
@@ -982,12 +981,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
     // @TODO: Incomplete.
     protected function update_order_meta( $post_id, $wpec_order ) {
 
-          // wpec tables
-        $wpsc_purchase_logs_table = $wpdb->prefix . 'wpsc_purchase_logs';
-        $wpsc_submited_form_data_table = $wpdb->prefix . 'wpsc_submited_form_data';
-        $wpsc_checkout_forms_table = $wpdb->prefix . 'wpsc_checkout_forms';
-      
-
+        
         /*
           ORDER DATA
         */
@@ -1000,21 +994,44 @@ if (!class_exists("ralc_wpec_to_woo")) {
           "), $wpec_order['id'] );
 
 
+        
+
         update_post_meta( $post_id, '_payment_method', $extrainfo->gateway );
-
-        // @TODO: Fix these. They should not all be the same. 
-        update_post_meta( $post_id, '_order_shipping', $extrainfo->base_shipping );
-        update_post_meta( $post_id, '_order_discount', $extrainfo->base_shipping );
-        update_post_meta( $post_id, '_cart_discount', $extrainfo->base_shipping );
-        update_post_meta( $post_id, '_order_tax', $extrainfo->base_shipping );
-        update_post_meta( $post_id, '_order_shipping_tax', $extrainfo->base_shipping );
-        update_post_meta( $post_id, '_order_total', $extrainfo->totalprice );
         update_post_meta( $post_id, '_order_key',  'wc_' . apply_filters( 'woocommerce_generate_order_key', uniqid( 'order_' ) ) );
-        update_post_meta( $post_id, '_order_currency', "EUR" );
-        update_post_meta( $post_id, '_prices_include_tax', "no" );
+
+        update_post_meta( $post_id, '_payment_method_title', '' );
+        update_post_meta( $post_id, '_transaction_id', '' );
+        
+        
+        update_post_meta( $post_id, '_order_currency', $this->default_order_currency );
+
+        update_post_meta( $post_id, '_prices_include_tax', '' );
+        update_post_meta( $post_id, '_order_shipping', '' );
+        update_post_meta( $post_id, '_order_discount', '' );
+        update_post_meta( $post_id, '_cart_discount', '' );
+        update_post_meta( $post_id, '_order_tax', '' );
+        update_post_meta( $post_id, '_order_shipping_tax', '' );
+        update_post_meta( $post_id, '_order_total', '' );
+        
 
 
 
+
+
+    }
+
+    // @TODO: Incomplete.
+    protected function update_order_authorize_net_info( $post_id, $wpec_order ) {
+
+      update_post_meta( $post_id, '_wc_authorize_net_aim_retry_amount', '0' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_trans_id', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_trans_date', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_environment', 'production' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_account_four', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_authorization_amount', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_authorization_code', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_charge_captured', '' );
+      update_post_meta( $post_id, '_wc_authorize_net_aim_card_type', '' );
 
     }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -62,6 +62,32 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
 
     }
+
+    /**
+     * Adds WP e-Commerce Metadata table names to the $wpdb object so that WP's 
+     * get_metadata() works.
+     * 
+     * @return void
+     */
+    function enable_wpec_meta() {
+
+      global $wpdb;
+      
+      if( empty( $wpdb->wpsc_meta ) ) {
+        $wpdb->wpsc_meta                = $wpdb->prefix . 'wpsc_meta';
+      }
+      if( empty( $wpdb->wpsc_cart_itemmeta ) ) {
+        $wpdb->wpsc_cart_itemmeta       = $wpdb->prefix . 'wpsc_cart_item_meta';
+      }
+      if( empty( $wpdb->wpsc_purchasemeta ) ) {
+        $wpdb->wpsc_purchasemeta        = $wpdb->prefix . 'wpsc_purchase_meta';
+      
+      }
+      if( empty( $wpdb->wpsc_visitormeta ) ) {
+        $wpdb->wpsc_visitormeta         = $wpdb->prefix . 'wpsc_visitor_meta';
+      }
+    }
+
     
     public function plugin_menu() {
       $page = add_submenu_page( 'tools.php', 'wpec to woo', 'wpec to woo', 'manage_options', 'wpec-to-woo', array( $this, 'plugin_options' ) );
@@ -335,6 +361,9 @@ if (!class_exists("ralc_wpec_to_woo")) {
       // Don't send E-mail by accident while converting. 
       // We don't want customers getting a bunch of E-mails!
       $this->disable_emails();
+
+      // Make get_metadata() work for WPeC's meta tables, even if WPeC is not activated.
+      $this->enable_wpec_meta();
       // just get the id of the first administrator in the database
     	$this->post_author = $wpdb->get_var( "SELECT ID FROM $wpdb->users;" );
     	$this->update_shop_settings();          

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -903,58 +903,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         $wpsc_submited_form_data_table = $wpdb->prefix . 'wpsc_submited_form_data';
         $wpsc_checkout_forms_table = $wpdb->prefix . 'wpsc_checkout_forms';
 
-        /*
-          CUSTOMER DATA
-        */
-        $userinfo = $wpdb->get_results("
-          SELECT 
-          `" . $wpsc_submited_form_data_table . "`.`value`,
-          `" . $wpsc_checkout_forms_table . "`.`name`,
-          `" . $wpsc_checkout_forms_table . "`.`unique_name`
-          FROM `" . $wpsc_checkout_forms_table . "`
-          LEFT JOIN `" . $wpsc_submited_form_data_table . "`
-          ON `" . $wpsc_checkout_forms_table . "`.id = `" . $wpsc_submited_form_data_table . "`.`form_id`
-          WHERE `" . $wpsc_submited_form_data_table . "`.`log_id`=" . $order['id'] . "
-          ORDER BY `" . $wpsc_checkout_forms_table . "`.`checkout_order`
-          ", ARRAY_A );
-        foreach($userinfo as $info){
-          $userinfo[$info['unique_name']] = $info['value'];
-        }
-
-        // ID
-        update_post_meta( $post_id, '_customer_user', $order['user_ID'] );
-
-        // billing address
-        update_post_meta( $post_id, '_billing_first_name', $userinfo['billingfirstname'] );
-        update_post_meta( $post_id, '_billing_last_name', $userinfo['billinglastname'] );
-        update_post_meta( $post_id, '_billing_address_1', $userinfo['billingaddress'] );
-        update_post_meta( $post_id, '_billing_address_2', "" );
-        update_post_meta( $post_id, '_billing_city', $userinfo['billingcity'] );
-        update_post_meta( $post_id, '_billing_postcode', $userinfo['billingpostcode'] );
-        if( isset( $userinfo['billingcountry'])) {
-          update_post_meta( $post_id, '_billing_country', $userinfo['billingcountry'] );
-        } else {
-          update_post_meta( $post_id, '_billing_country', $this->default_billing_country );
-        }
-        
-        update_post_meta( $post_id, '_billing_email', $userinfo['billingemail'] );
-        update_post_meta( $post_id, '_billing_phone', $userinfo['billingphone'] );                
-
-        // shipping address
-        update_post_meta( $post_id, '_shipping_first_name', $userinfo['shippingfirstname'] );
-        update_post_meta( $post_id, '_shipping_last_name', $userinfo['shippinglastname'] );
-        update_post_meta( $post_id, '_shipping_company', "" );
-        update_post_meta( $post_id, '_shipping_address_1', $userinfo['shippingaddress'] );
-        update_post_meta( $post_id, '_shipping_address_2', "" );
-        update_post_meta( $post_id, '_shipping_city', $userinfo['shippingcity'] );
-        update_post_meta( $post_id, '_shipping_postcode', $userinfo['shippingpostcode'] );
-        if(isset($userinfo['shippingcountry'])) {
-          update_post_meta( $post_id, '_shipping_country', $userinfo['shippingcountry'] );
-        } else {
-          update_post_meta( $post_id, '_shipping_country', $this->default_shipping_country );
-        }
-        update_post_meta( $post_id, '_shipping_state', "" );
-
+        $this->update_order_contact_info( $post_id, $order);
 
         $this->update_order_items( $post_id, $order );
 
@@ -968,6 +917,68 @@ if (!class_exists("ralc_wpec_to_woo")) {
         }
 
     }// END: update_orders()
+
+    protected function update_order_contact_info( $post_id, $wpec_order ) {
+
+      global $wpdb;
+
+      
+
+      /*
+        CUSTOMER DATA
+      */
+      $userinfo = $wpdb->get_results( $wpdb->prepare("
+        SELECT 
+        `{$wpdb->previx}wpsc_submited_form_data`.`value`,
+        `{$wpdb->prefix}wpsc_checkout_forms`.`name`,
+        `{$wpdb->prefix}wpsc_checkout_forms`.`unique_name`
+        FROM `{$wpdb->prefix}wpsc_checkout_forms`
+        LEFT JOIN `{$wpdb->previx}wpsc_submited_form_data`
+        ON `{$wpdb->prefix}wpsc_checkout_forms`.id = `{$wpdb->previx}wpsc_submited_form_data`.`form_id`
+        WHERE `{$wpdb->previx}wpsc_submited_form_data`.`log_id`=%d
+        ORDER BY `{$wpdb->prefix}wpsc_checkout_forms`.`checkout_order`
+        ", $wpec_order['id'] ), ARRAY_A );
+
+
+      foreach($userinfo as $info){
+        $userinfo[$info['unique_name']] = $info['value'];
+      }
+
+      // ID
+      update_post_meta( $post_id, '_customer_user', $wpec_order['user_ID'] );
+
+      // billing address
+      update_post_meta( $post_id, '_billing_first_name', $userinfo['billingfirstname'] );
+      update_post_meta( $post_id, '_billing_last_name', $userinfo['billinglastname'] );
+      update_post_meta( $post_id, '_billing_address_1', $userinfo['billingaddress'] );
+      update_post_meta( $post_id, '_billing_address_2', "" );
+      update_post_meta( $post_id, '_billing_city', $userinfo['billingcity'] );
+      update_post_meta( $post_id, '_billing_postcode', $userinfo['billingpostcode'] );
+      if( isset( $userinfo['billingcountry'])) {
+        update_post_meta( $post_id, '_billing_country', $userinfo['billingcountry'] );
+      } else {
+        update_post_meta( $post_id, '_billing_country', $this->default_billing_country );
+      }
+      
+      update_post_meta( $post_id, '_billing_email', $userinfo['billingemail'] );
+      update_post_meta( $post_id, '_billing_phone', $userinfo['billingphone'] );                
+
+      // shipping address
+      update_post_meta( $post_id, '_shipping_first_name', $userinfo['shippingfirstname'] );
+      update_post_meta( $post_id, '_shipping_last_name', $userinfo['shippinglastname'] );
+      update_post_meta( $post_id, '_shipping_company', "" );
+      update_post_meta( $post_id, '_shipping_address_1', $userinfo['shippingaddress'] );
+      update_post_meta( $post_id, '_shipping_address_2', "" );
+      update_post_meta( $post_id, '_shipping_city', $userinfo['shippingcity'] );
+      update_post_meta( $post_id, '_shipping_postcode', $userinfo['shippingpostcode'] );
+      if(isset($userinfo['shippingcountry'])) {
+        update_post_meta( $post_id, '_shipping_country', $userinfo['shippingcountry'] );
+      } else {
+        update_post_meta( $post_id, '_shipping_country', $this->default_shipping_country );
+      }
+      update_post_meta( $post_id, '_shipping_state', "" );
+
+    }
 
 
     // @TODO: Incomplete.

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -550,12 +550,14 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
 
         // featured?
-      if (in_array($post_id, $featured_products)) {
-        $featured = 'yes';
-      }else{
-        $featured = 'no';
-      }
-      update_post_meta($post_id, '_featured', $featured);            
+      if( is_array( $featured_products ) ) {
+        if (in_array($post_id, $featured_products)) {
+          $featured = 'yes';
+        }else{
+          $featured = 'no';
+        }
+        update_post_meta($post_id, '_featured', $featured);
+      }       
       // ______________________________
 
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -934,6 +934,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
           'post_status' => self::convert_order_status($order['processed']),
           'post_title' => $post_title,
           'post_type' => 'shop_order',
+          'post_password' => uniqid( 'order_' ),
           'post_date' => date_i18n( 'Y-m-d H:i:s', $order['date'] ),
           'post_date_gmt' => date_i18n( 'Y-m-d H:i:s', $order['date'], true ),
           );

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -139,7 +139,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       }
       ?>
       <div class="wrap">
-        <h2>Wp-e-commerce to woocommerce converter</h2>
+        <h2>WP e-Commerce to WooCommerce Converter</h2>
         <p>Use at your own risk!, still working on it, only use it on a test version of your site. Read the help for more information.</p>         
         <?php
         if( isset($_POST['delete_orders']) && $_POST['delete_orders'] == 'yes' ){

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -726,10 +726,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
         );
         $children = get_children( $args );
 
-        $has_variations[$id] = ! empty( $children );
+        $has_variations[$post_id] = ! empty( $children );
       }
 
-      return $has_variations[$id];
+      return $has_variations[$post_id];
     }
 
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1044,13 +1044,13 @@ if (!class_exists("ralc_wpec_to_woo")) {
       */
       $userinfo = $wpdb->get_results( $wpdb->prepare("
         SELECT 
-        `{$wpdb->previx}wpsc_submited_form_data`.`value`,
+        `{$wpdb->prefix}wpsc_submited_form_data`.`value`,
         `{$wpdb->prefix}wpsc_checkout_forms`.`name`,
         `{$wpdb->prefix}wpsc_checkout_forms`.`unique_name`
         FROM `{$wpdb->prefix}wpsc_checkout_forms`
-        LEFT JOIN `{$wpdb->previx}wpsc_submited_form_data`
-        ON `{$wpdb->prefix}wpsc_checkout_forms`.id = `{$wpdb->previx}wpsc_submited_form_data`.`form_id`
-        WHERE `{$wpdb->previx}wpsc_submited_form_data`.`log_id`=%d
+        LEFT JOIN `{$wpdb->prefix}wpsc_submited_form_data`
+        ON `{$wpdb->prefix}wpsc_checkout_forms`.id = `{$wpdb->prefix}wpsc_submited_form_data`.`form_id`
+        WHERE `{$wpdb->prefix}wpsc_submited_form_data`.`log_id`=%d
         ORDER BY `{$wpdb->prefix}wpsc_checkout_forms`.`checkout_order`
         ", $wpec_order['id'] ), ARRAY_A );
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -959,9 +959,12 @@ if (!class_exists("ralc_wpec_to_woo")) {
           break;
 
           case 'wpsc_merchant_paypal_express':
+            // It looks like nothing is stored anywhere other than purchlog table for PayPal Express
+            // Not even Transaction ID or Authcode exist in purchlog table.
           break;
 
           case 'wpsc_merchant_vmerchant':
+            // It looks like nothing is stored anywhere other than purchlog table for vmerchant.
           break;
         }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1324,6 +1324,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       } else {
         update_post_meta( $post_id, '_billing_country', $this->default_billing_country );
       }
+      update_post_meta( $post_id, '_billing_state', $userinfo['billingstate'] );
       
       update_post_meta( $post_id, '_billing_email', $userinfo['billingemail'] );
       update_post_meta( $post_id, '_billing_phone', $userinfo['billingphone'] );                
@@ -1341,7 +1342,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
       } else {
         update_post_meta( $post_id, '_shipping_country', $this->default_shipping_country );
       }
-      update_post_meta( $post_id, '_shipping_state', "" );
+      update_post_meta( $post_id, '_shipping_state', $userinfo['shippingstate'] );
 
       /**
        * Action 'wpec_to_woo_update_order_submitted_form_data'

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -411,7 +411,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     	$this->update_coupons();
     	
-//      $this->update_orders();
+      $this->update_orders();
 
       // tags don't need to be updated as both wpec and woo use the same name for the taxonomy 'product_tag'
       // $this->delete_redundant_wpec_datbase_entries();         

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -977,7 +977,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_order_tax', $extrainfo->base_shipping );
         update_post_meta( $post_id, '_order_shipping_tax', $extrainfo->base_shipping );
         update_post_meta( $post_id, '_order_total', $extrainfo->totalprice );
-        update_post_meta( $post_id, '_order_key', uniqid( 'order_' ) );
+        update_post_meta( $post_id, '_order_key',  'wc_' . apply_filters( 'woocommerce_generate_order_key', uniqid( 'order_' ) ) );
         update_post_meta( $post_id, '_order_currency', "EUR" );
         update_post_meta( $post_id, '_prices_include_tax', "no" );
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -861,6 +861,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
     
     public function update_orders(){
       global $wpdb;
+      
       // loop through orders
       $wpec_order_table = $wpdb->prefix . 'wpsc_purchase_logs';
       $wpec_formdata_table = $wpdb->prefix . 'wpsc_submited_form_data';
@@ -898,7 +899,6 @@ if (!class_exists("ralc_wpec_to_woo")) {
         $post_id = wp_insert_post( $post, true );
 
         // wpec tables
-        $wpsc_cart_contents_table = $wpdb->prefix . 'wpsc_cart_contents';
         $wpsc_purchase_logs_table = $wpdb->prefix . 'wpsc_purchase_logs';
         $wpsc_submited_form_data_table = $wpdb->prefix . 'wpsc_submited_form_data';
         $wpsc_checkout_forms_table = $wpdb->prefix . 'wpsc_checkout_forms';
@@ -1013,13 +1013,14 @@ if (!class_exists("ralc_wpec_to_woo")) {
      * @return void
      */
     protected function update_order_items( $post_id, $wpec_order )  {
+        global $wpdb;
 
         /*
           ORDER ITEMS
         */
         $cartcontent = $wpdb->get_results("
           SELECT * 
-          FROM `" . $wpsc_cart_contents_table . "` 
+          FROM `{$wpdb->prefix}wpsc_cart_contents` 
           WHERE `purchaseid`=" . $wpec_order['id'] . "
           ");
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1220,7 +1220,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
 
         // Refactor opportunity! These should all be part of their own object.
-        $this->update_order_contact_info( $post_id, $order, $current_wc_order );
+        $this->update_order_submitted_form_data( $post_id, $order, $current_wc_order );
 
         $this->update_order_items( $post_id, $order, $current_wc_order );
 
@@ -1267,7 +1267,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
 
     }// END: update_orders()
 
-    protected function update_order_contact_info( $post_id, $wpec_order, \WC_Order $current_wc_order ) {
+    protected function update_order_submitted_form_data( $post_id, $wpec_order, \WC_Order $current_wc_order ) {
 
       global $wpdb;
 
@@ -1337,6 +1337,17 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_shipping_country', $this->default_shipping_country );
       }
       update_post_meta( $post_id, '_shipping_state', "" );
+
+      /**
+       * Action 'wpec_to_woo_update_order_submitted_form_data'
+       *
+       * @param int $post_id The post ID of the WooCommerce Order CPT created for this order.
+       * @param array $order Row from WPeC's Purchase Log table that is the source of the migrated order.
+       * @param \WC_Order $current_wc_order The WooCommerce order object that corresponds to $post_id.
+       * @param array $userinfo An array of data from the submitted_form_data table, with keys matching the unique name
+       *                        in the forms table.
+       */
+      do_action( 'wpec_to_woo_update_order_submitted_form_data', $post_id, $wpec_order, $current_wc_order, $userinfo );
 
     }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1266,6 +1266,11 @@ if (!class_exists("ralc_wpec_to_woo")) {
         
         // Set the "Prices Include Tax" item based on the WPeC store setting.
         update_post_meta( $post_id, '_prices_include_tax', ( $this->taxes_included ? 'yes' : 'no' ) );
+
+        // If order is at least in an "accepted payment" state, record a payment date.
+        if( $wpec_order['processed'] > 2 ) {
+          update_post_meta( $post_id, '_wc_authorize_net_aim_trans_date', date_i18n( 'Y-m-d H:i:s', $wpec_order['date'], true ) );
+        }
         
     }
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1251,6 +1251,15 @@ if (!class_exists("ralc_wpec_to_woo")) {
         update_post_meta( $post_id, '_order_discount', $wpec_order['discount_value'] );
         update_post_meta( $post_id, '_order_tax', $wpec_order['wpec_taxes_total'] );
         update_post_meta( $post_id, '_order_total', $wpec_order['totalprice'] );
+
+
+        // Save the "How did you find us?" response. Woo doesn't do anythign with this by default
+        // but this way it's there if we want to use it later. 
+        update_post_meta( $post_id, '_customer_source', $wpec_order['find_us'] );
+
+        // We'll also put it in an order note:
+        $current_wc_order->add_order_note( sprintf('Customer Source: %s', $wpec_order['find_us'] ) );
+
         
 
         // Update hardcoded or generated values.

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -448,12 +448,12 @@ if (!class_exists("ralc_wpec_to_woo")) {
                   </tr>
                   <tr>
                     <td><a href="post.php/<?php echo $coupon["link"] ?>"><?php echo $coupon["title"] ?></a></td>
-                    <td><?php echo $coupon["active"] ?></td>
-                    <?php if($coupon["conditions"] && $coupon["free-shipping"] ): ?>
+                    <td><?php echo (isset($coupon['active']) ? $coupon['active'] : '' ); ?></td>
+                    <?php if(isset($coupon["conditions"]) && $coupon["conditions"] && isset($coupon["free-shipping"]) && $coupon["free-shipping"] ): ?>
                     <td>This coupon was set to be in-active because it currently makes use of the conditions feature and the free shipping of wpec which is not supported by woocommerce</td>
-                    <?php elseif($coupon["conditions"]): ?>
+                    <?php elseif(isset($coupon["conditions"]) && $coupon["conditions"]): ?>
                     <td>This coupon was set to be in-active because it currently makes use of the conditions feature of wpec which is not supported by woocommerce</td>
-                    <?php elseif($coupon["free-shipping"]): ?>
+                    <?php elseif(isset($coupon["free-shipping"]) && $coupon["free-shipping"]): ?>
                     <td>This coupon was set to be in-active because it currently makes use of the free shipping feature of wpec which is not supported by woocommerce</td>
                     <?php endif; ?>
                   </tr>

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -70,7 +70,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
           <input class="button-primary" type="submit" value="Convert My Store" />
         </form>
         <?php
-        if( $_POST['order'] == 'go_go_go' ){          
+        if( isset($_POST['order']) && $_POST['order'] == 'go_go_go' ){          
           $this->show_log();
         }
         ?>

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -280,6 +280,10 @@ if (!class_exists("ralc_wpec_to_woo")) {
                 </div><!-- .table -->
 
               </div><!-- .inside -->
+
+              <div class="inside">
+                <p><strong>Note:</strong> If WP e-Commerce is currently deactivated then Products and Product Categories will show zero even if there are products and categories in the database.</p>
+              </div>
             </div><!-- .postbox -->
           </div><!-- .postbox-container -->
 

--- a/wpec-to-woo/wpec-to-woo.php
+++ b/wpec-to-woo/wpec-to-woo.php
@@ -1012,7 +1012,7 @@ if (!class_exists("ralc_wpec_to_woo")) {
         // wpsc_merchant_vmerchant
         switch( $order['gateway'] ) {
           case 'wpec_auth_net':
-            $this->update_wpec_auth_net();
+            $this->update_wpec_auth_net( $post_id, $order );
           break;
 
           case 'wpsc_merchant_paypal_express':


### PR DESCRIPTION
This PR updates the converter for late 2018. Like your original, this works for me, but should be used with extreme caution.  Here's a highlight list of what's in here:

- Transfer product attributes from WPeC
- Transfer product variations
- Improve transfer of Orders
- Transfer some payment info with orders, when available.
- Fix: Sale price always zero is now fixed.
- PHP5+ constructor on the object.
- Extend timeouts as we iterate through products & orders so the script completes for large stores
- Set some defaults
- Fix some array key doesn't exist notices.
- Add hooks do devs can extend the converter more, if needed.
- Updated "works with" versions of WPeC and WooCommerce.

I tried to keep the commits pretty atomic, so there's more detail there.

If you're no longer interested in maintaining the plugin let me know and I'll put start logging tickets against my fork.